### PR TITLE
ApplicationLinks Service implementation and commons 0.0.20 mods

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -31,6 +31,284 @@ This plugin provides methods for accessing configuration for Bitbucket.
 == Endpoints
 
 
+[.ApplicationLinks]
+=== ApplicationLinks
+
+
+[.addApplicationLink]
+==== addApplicationLink
+    
+`POST /application-links`
+
+Add a single application link
+
+===== Description 
+
+Upon successful request, returns the added `ApplicationLinkBean` object
+
+
+// markup not found, no include::{specDir}application-links/POST/spec.adoc[opts=optional]
+
+
+
+===== Parameters
+
+
+===== Body Parameter
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| ApplicationLinkBean 
+|  <<ApplicationLinkBean>> 
+| X 
+|  
+|  
+
+|===         
+
+
+
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| ignore-setup-errors 
+|   
+| - 
+| false 
+|  
+
+|===         
+
+
+===== Return Type
+
+<<ApplicationLinkBean>>
+
+
+===== Content Type
+
+* application/json
+
+===== Responses
+
+.http response codes
+[cols="2,3,1"]
+|===         
+| Code | Message | Datatype 
+
+
+| 200
+| 
+|  <<ApplicationLinkBean>>
+
+
+| 0
+| 
+|  <<ErrorCollection>>
+
+|===         
+
+===== Samples
+
+
+// markup not found, no include::{snippetDir}application-links/POST/http-request.adoc[opts=optional]
+
+
+// markup not found, no include::{snippetDir}application-links/POST/http-response.adoc[opts=optional]
+
+
+
+// file not found, no * wiremock data link :application-links/POST/POST.json[]
+
+
+ifdef::internal-generation[]
+===== Implementation
+
+// markup not found, no include::{specDir}application-links/POST/implementation.adoc[opts=optional]
+
+
+endif::internal-generation[]
+
+
+[.getApplicationLinks]
+==== getApplicationLinks
+    
+`GET /application-links`
+
+Get all application links
+
+===== Description 
+
+Upon successful request, returns a `ApplicationLinksBean` object containing all application links
+
+
+// markup not found, no include::{specDir}application-links/GET/spec.adoc[opts=optional]
+
+
+
+===== Parameters
+
+
+
+
+
+
+
+===== Return Type
+
+<<ApplicationLinksBean>>
+
+
+===== Content Type
+
+* application/json
+
+===== Responses
+
+.http response codes
+[cols="2,3,1"]
+|===         
+| Code | Message | Datatype 
+
+
+| 200
+| 
+|  <<ApplicationLinksBean>>
+
+
+| 0
+| 
+|  <<ErrorCollection>>
+
+|===         
+
+===== Samples
+
+
+// markup not found, no include::{snippetDir}application-links/GET/http-request.adoc[opts=optional]
+
+
+// markup not found, no include::{snippetDir}application-links/GET/http-response.adoc[opts=optional]
+
+
+
+// file not found, no * wiremock data link :application-links/GET/GET.json[]
+
+
+ifdef::internal-generation[]
+===== Implementation
+
+// markup not found, no include::{specDir}application-links/GET/implementation.adoc[opts=optional]
+
+
+endif::internal-generation[]
+
+
+[.setApplicationLinks]
+==== setApplicationLinks
+    
+`PUT /application-links`
+
+Set a new set of application links
+
+===== Description 
+
+Upon successful request, returns a `ApplicationLinksBean` object containing all application links
+
+
+// markup not found, no include::{specDir}application-links/PUT/spec.adoc[opts=optional]
+
+
+
+===== Parameters
+
+
+===== Body Parameter
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| ApplicationLinksBean 
+|  <<ApplicationLinksBean>> 
+| X 
+|  
+|  
+
+|===         
+
+
+
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| ignore-setup-errors 
+|   
+| - 
+| false 
+|  
+
+|===         
+
+
+===== Return Type
+
+<<ApplicationLinksBean>>
+
+
+===== Content Type
+
+* application/json
+
+===== Responses
+
+.http response codes
+[cols="2,3,1"]
+|===         
+| Code | Message | Datatype 
+
+
+| 200
+| 
+|  <<ApplicationLinksBean>>
+
+
+| 0
+| 
+|  <<ErrorCollection>>
+
+|===         
+
+===== Samples
+
+
+// markup not found, no include::{snippetDir}application-links/PUT/http-request.adoc[opts=optional]
+
+
+// markup not found, no include::{snippetDir}application-links/PUT/http-response.adoc[opts=optional]
+
+
+
+// file not found, no * wiremock data link :application-links/PUT/PUT.json[]
+
+
+ifdef::internal-generation[]
+===== Implementation
+
+// markup not found, no include::{specDir}application-links/PUT/implementation.adoc[opts=optional]
+
+
+endif::internal-generation[]
+
+
 [.Ping]
 === Ping
 
@@ -274,6 +552,92 @@ endif::internal-generation[]
 == Models
 
 
+[#ApplicationLinkBean]
+=== _ApplicationLinkBean_ 
+
+
+
+[.fields-ApplicationLinkBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| serverId 
+|  
+| String  
+| 
+|  
+
+| name 
+| X 
+| String  
+| 
+|  
+
+| type 
+| X 
+| String  
+| 
+|  _Enum:_ BAMBOO, JIRA, BITBUCKET, CONFLUENCE, FISHEYE, CROWD, 
+
+| displayUrl 
+| X 
+| URI  
+| 
+| uri 
+
+| rpcUrl 
+| X 
+| URI  
+| 
+| uri 
+
+| primary 
+|  
+| Boolean  
+| 
+|  
+
+| status 
+|  
+| String  
+| 
+|  _Enum:_ AVAILABLE, UNAVAILABLE, CONFIGURATION_ERROR, 
+
+| username 
+|  
+| String  
+| 
+|  
+
+| password 
+|  
+| String  
+| 
+|  
+
+|===
+
+
+[#ApplicationLinksBean]
+=== _ApplicationLinksBean_ 
+
+
+
+[.fields-ApplicationLinksBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| applicationLinks 
+|  
+| List  of <<ApplicationLinkBean>> 
+| 
+|  
+
+|===
+
+
 [#ErrorCollection]
 === _ErrorCollection_ 
 
@@ -305,9 +669,9 @@ endif::internal-generation[]
 
 | baseUrl 
 |  
-| String  
+| URI  
 | 
-|  
+| uri 
 
 | mode 
 |  

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>confapi-bitbucket-plugin</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>ConfAPI for Bitbucket</name>
@@ -59,7 +59,7 @@
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
         <atlassian.plugins.rest.version>5.0.1</atlassian.plugins.rest.version>
-        <confapi-commons.version>0.0.18-SNAPSHOT</confapi-commons.version>
+        <confapi-commons.version>0.0.20-SNAPSHOT</confapi-commons.version>
         <javax.inject.version>1</javax.inject.version>
         <jsr311.version>1.1.1</jsr311.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
@@ -114,6 +114,24 @@
         </dependency>
 
         <dependency>
+            <groupId>com.atlassian.applinks</groupId>
+            <artifactId>applinks-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.applinks</groupId>
+            <artifactId>applinks-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.applinks</groupId>
+            <artifactId>applinks-plugin</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
@@ -146,15 +164,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>2.2.6</version>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/src/main/java/de/aservo/confapi/bitbucket/filter/SysAdminOnlyResourceFilter.java
+++ b/src/main/java/de/aservo/confapi/bitbucket/filter/SysAdminOnlyResourceFilter.java
@@ -40,7 +40,7 @@ public class SysAdminOnlyResourceFilter implements ResourceFilter, ContainerRequ
     }
 
     public boolean isSystemAdministrator(ApplicationUser user) {
-        return permissionService.hasUserPermission(user, SYS_ADMIN);
+        return permissionService.hasGlobalPermission(user, SYS_ADMIN);
     }
 
     // these methods should be implemented in abstract parents in commons, but how to deal with Atlassian deps?

--- a/src/main/java/de/aservo/confapi/bitbucket/model/DefaultAuthenticationScenario.java
+++ b/src/main/java/de/aservo/confapi/bitbucket/model/DefaultAuthenticationScenario.java
@@ -1,0 +1,18 @@
+package de.aservo.confapi.bitbucket.model;
+
+import com.atlassian.applinks.spi.auth.AuthenticationScenario;
+
+/**
+ * The type Default authentication scenario.
+ */
+public class DefaultAuthenticationScenario implements AuthenticationScenario {
+    @Override
+    public boolean isCommonUserBase() {
+        return true;
+    }
+
+    @Override
+    public boolean isTrusted() {
+        return true;
+    }
+}

--- a/src/main/java/de/aservo/confapi/bitbucket/model/util/ApplicationLinkBeanUtil.java
+++ b/src/main/java/de/aservo/confapi/bitbucket/model/util/ApplicationLinkBeanUtil.java
@@ -1,0 +1,86 @@
+package de.aservo.confapi.bitbucket.model.util;
+
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.api.application.bamboo.BambooApplicationType;
+import com.atlassian.applinks.api.application.bitbucket.BitbucketApplicationType;
+import com.atlassian.applinks.api.application.confluence.ConfluenceApplicationType;
+import com.atlassian.applinks.api.application.crowd.CrowdApplicationType;
+import com.atlassian.applinks.api.application.fecru.FishEyeCrucibleApplicationType;
+import com.atlassian.applinks.api.application.jira.JiraApplicationType;
+import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
+import de.aservo.confapi.commons.model.ApplicationLinkBean;
+import org.apache.commons.lang3.NotImplementedException;
+
+import javax.validation.constraints.NotNull;
+
+import static de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkTypes.*;
+
+public class ApplicationLinkBeanUtil {
+
+    /**
+     * Instantiates a new Application link bean.
+     *
+     * @param linkDetails the link details
+     */
+    @NotNull
+    public static ApplicationLinkBean toApplicationLinkBean(
+            @NotNull final ApplicationLink linkDetails) {
+
+        final ApplicationLinkBean applicationLinkBean = new ApplicationLinkBean();
+        applicationLinkBean.setServerId(linkDetails.getId().toString());
+        applicationLinkBean.setName(linkDetails.getName());
+        applicationLinkBean.setType(getLinkTypeFromAppType(linkDetails.getType()));
+        applicationLinkBean.setDisplayUrl(linkDetails.getDisplayUrl());
+        applicationLinkBean.setRpcUrl(linkDetails.getRpcUrl());
+        applicationLinkBean.setPrimary(linkDetails.isPrimary());
+        return applicationLinkBean;
+    }
+
+    /**
+     * To application link details application link details.
+     *
+     * @return the application link details
+     */
+    @NotNull
+    public static ApplicationLinkDetails toApplicationLinkDetails(
+            @NotNull final ApplicationLinkBean applicationLinkBean) {
+
+        return ApplicationLinkDetails.builder()
+                .name(applicationLinkBean.getName())
+                .displayUrl(applicationLinkBean.getDisplayUrl())
+                .rpcUrl(applicationLinkBean.getRpcUrl())
+                .isPrimary(applicationLinkBean.isPrimary())
+                .build();
+    }
+
+    /**
+     * Gets the linktype ApplicationLinkTypes enum value.
+     *
+     * @param type the ApplicationType
+     * @return the linktype
+     */
+    private static ApplicationLinkBean.ApplicationLinkTypes getLinkTypeFromAppType(
+            @NotNull final ApplicationType type) {
+
+        if (type instanceof BambooApplicationType) {
+            return BAMBOO;
+        } else if (type instanceof JiraApplicationType) {
+            return JIRA;
+        } else if (type instanceof BitbucketApplicationType) {
+            return BITBUCKET;
+        } else if (type instanceof ConfluenceApplicationType) {
+            return CONFLUENCE;
+        } else if (type instanceof FishEyeCrucibleApplicationType) {
+            return FISHEYE;
+        } else if (type instanceof CrowdApplicationType) {
+            return CROWD;
+        } else {
+            throw new NotImplementedException("application type '" + type.getClass() + "' not implemented");
+        }
+    }
+
+    private ApplicationLinkBeanUtil() {
+    }
+
+}

--- a/src/main/java/de/aservo/confapi/bitbucket/rest/ApplicationLinksResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/bitbucket/rest/ApplicationLinksResourceImpl.java
@@ -1,0 +1,22 @@
+package de.aservo.confapi.bitbucket.rest;
+
+import com.sun.jersey.spi.container.ResourceFilters;
+import de.aservo.confapi.bitbucket.filter.SysAdminOnlyResourceFilter;
+import de.aservo.confapi.commons.constants.ConfAPI;
+import de.aservo.confapi.commons.rest.AbstractApplicationLinksResourceImpl;
+import de.aservo.confapi.commons.service.api.ApplicationLinksService;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.Path;
+
+@Named
+@Path(ConfAPI.APPLICATION_LINKS)
+@ResourceFilters(SysAdminOnlyResourceFilter.class)
+public class ApplicationLinksResourceImpl extends AbstractApplicationLinksResourceImpl {
+
+    @Inject
+    public ApplicationLinksResourceImpl(ApplicationLinksService applicationLinkService) {
+        super(applicationLinkService);
+    }
+}

--- a/src/main/java/de/aservo/confapi/bitbucket/service/ApplicationLinkServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/bitbucket/service/ApplicationLinkServiceImpl.java
@@ -1,0 +1,171 @@
+package de.aservo.confapi.bitbucket.service;
+
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.api.application.bamboo.BambooApplicationType;
+import com.atlassian.applinks.api.application.bitbucket.BitbucketApplicationType;
+import com.atlassian.applinks.api.application.confluence.ConfluenceApplicationType;
+import com.atlassian.applinks.api.application.crowd.CrowdApplicationType;
+import com.atlassian.applinks.api.application.fecru.FishEyeCrucibleApplicationType;
+import com.atlassian.applinks.api.application.jira.JiraApplicationType;
+import com.atlassian.applinks.core.ApplinkStatus;
+import com.atlassian.applinks.core.ApplinkStatusService;
+import com.atlassian.applinks.internal.common.exception.NoAccessException;
+import com.atlassian.applinks.internal.common.exception.NoSuchApplinkException;
+import com.atlassian.applinks.spi.auth.AuthenticationConfigurationException;
+import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
+import com.atlassian.applinks.spi.link.MutatingApplicationLinkService;
+import com.atlassian.applinks.spi.manifest.ManifestNotFoundException;
+import com.atlassian.applinks.spi.util.TypeAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import de.aservo.confapi.bitbucket.model.DefaultAuthenticationScenario;
+import de.aservo.confapi.commons.exception.BadRequestException;
+import de.aservo.confapi.commons.model.ApplicationLinkBean;
+import de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkTypes;
+import de.aservo.confapi.commons.model.ApplicationLinksBean;
+import de.aservo.confapi.commons.service.api.ApplicationLinksService;
+import org.apache.commons.lang3.NotImplementedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.validation.Validator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static com.atlassian.applinks.internal.status.error.ApplinkErrorType.CONNECTION_REFUSED;
+import static de.aservo.confapi.bitbucket.model.util.ApplicationLinkBeanUtil.toApplicationLinkBean;
+import static de.aservo.confapi.bitbucket.model.util.ApplicationLinkBeanUtil.toApplicationLinkDetails;
+import static de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkStatus.*;
+import static de.aservo.confapi.commons.util.BeanValidationUtil.processValidationResult;
+
+@Named
+@ExportAsService(ApplicationLinksService.class)
+public class ApplicationLinkServiceImpl implements ApplicationLinksService {
+
+    private static final Logger log = LoggerFactory.getLogger(ApplicationLinkServiceImpl.class);
+
+    private final MutatingApplicationLinkService mutatingApplicationLinkService;
+    private final TypeAccessor typeAccessor;
+    private final ApplinkStatusService applinkStatusService;
+    private final Validator validator;
+
+    @Inject
+    public ApplicationLinkServiceImpl(@ComponentImport MutatingApplicationLinkService mutatingApplicationLinkService,
+                                      @ComponentImport TypeAccessor typeAccessor,
+                                      @ComponentImport ApplinkStatusService applinkStatusService,
+                                      @ComponentImport Validator validator) {
+        this.mutatingApplicationLinkService = mutatingApplicationLinkService;
+        this.typeAccessor = typeAccessor;
+        this.applinkStatusService = applinkStatusService;
+        this.validator = validator;
+    }
+
+    @Override
+    public ApplicationLinksBean getApplicationLinks() {
+        Iterable<ApplicationLink> applicationLinksIterable = mutatingApplicationLinkService.getApplicationLinks();
+
+        List<ApplicationLinkBean> applicationLinkBeans = StreamSupport.stream(applicationLinksIterable.spliterator(),false)
+                .map(this::getApplicationLinkBeanWithStatus)
+                .collect(Collectors.toList());
+
+        return new ApplicationLinksBean(applicationLinkBeans);
+    }
+
+
+    @Override
+    public ApplicationLinksBean setApplicationLinks(
+            final ApplicationLinksBean applicationLinksBean,
+            final boolean ignoreSetupErrors) {
+
+        applicationLinksBean.getApplicationLinks().forEach(link -> addApplicationLink(link, ignoreSetupErrors));
+        return getApplicationLinks();
+    }
+
+    @Override
+    public ApplicationLinkBean addApplicationLink(
+            final ApplicationLinkBean linkBean,
+            final boolean ignoreSetupErrors) {
+
+        //preparations
+        processValidationResult(validator.validate(linkBean));
+
+        ApplicationLinkDetails linkDetails;
+        linkDetails = toApplicationLinkDetails(linkBean);
+
+        ApplicationType applicationType = buildApplicationType(linkBean.getType());
+
+        //check if there is already an application link of supplied type and if yes, remove it
+        Class<? extends ApplicationType> appType = applicationType != null ? applicationType.getClass() : null;
+        ApplicationLink primaryApplicationLink = mutatingApplicationLinkService.getPrimaryApplicationLink(appType);
+        if (primaryApplicationLink != null) {
+            log.info("An existing application link configuration '{}' was found and is removed now before adding the new configuration",
+                    primaryApplicationLink.getName());
+            mutatingApplicationLinkService.deleteApplicationLink(primaryApplicationLink);
+        }
+
+        //add new application link, this should always work - even if remote app is not accessible
+        ApplicationLink applicationLink;
+        try {
+            applicationLink = mutatingApplicationLinkService.createApplicationLink(applicationType, linkDetails);
+        } catch (ManifestNotFoundException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+
+        //configure authenticator, this might fail if setup is incorrect or remote app is unavailable
+        try {
+            mutatingApplicationLinkService.configureAuthenticationForApplicationLink(applicationLink,
+                    new DefaultAuthenticationScenario(), linkBean.getUsername(), linkBean.getPassword());
+        } catch (AuthenticationConfigurationException e) {
+            if (!ignoreSetupErrors) {
+                throw new BadRequestException(e.getMessage());
+            }
+        }
+
+        return getApplicationLinkBeanWithStatus(applicationLink);
+    }
+
+    private ApplicationType buildApplicationType(ApplicationLinkTypes linkType) {
+        switch (linkType) {
+            case BAMBOO:
+                return typeAccessor.getApplicationType(BambooApplicationType.class);
+            case JIRA:
+                return typeAccessor.getApplicationType(JiraApplicationType.class);
+            case BITBUCKET:
+                return typeAccessor.getApplicationType(BitbucketApplicationType.class);
+            case CONFLUENCE:
+                return typeAccessor.getApplicationType(ConfluenceApplicationType.class);
+            case FISHEYE:
+                return typeAccessor.getApplicationType(FishEyeCrucibleApplicationType.class);
+            case CROWD:
+                return typeAccessor.getApplicationType(CrowdApplicationType.class);
+            default:
+                throw new NotImplementedException("application type '" + linkType + "' not implemented");
+        }
+    }
+
+    private ApplicationLinkBean getApplicationLinkBeanWithStatus(ApplicationLink applicationLink) {
+
+        ApplicationLinkBean applicationLinkBean = toApplicationLinkBean(applicationLink);
+
+        try {
+            ApplinkStatus applinkStatus = applinkStatusService.getApplinkStatus(applicationLink.getId());
+            if (applinkStatus.isWorking()) {
+                applicationLinkBean.setStatus(AVAILABLE);
+            } else {
+                if (applinkStatus.getError() != null && CONNECTION_REFUSED.equals(applinkStatus.getError().getType())) {
+                    applicationLinkBean.setStatus(UNAVAILABLE);
+                } else {
+                    applicationLinkBean.setStatus(CONFIGURATION_ERROR);
+                }
+            }
+        } catch (NoAccessException | NoSuchApplinkException e) {
+            applicationLinkBean.setStatus(CONFIGURATION_ERROR);
+        }
+
+        return applicationLinkBean;
+    }
+}

--- a/src/main/java/de/aservo/confapi/bitbucket/service/SettingsServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/bitbucket/service/SettingsServiceImpl.java
@@ -9,7 +9,6 @@ import de.aservo.confapi.commons.service.api.SettingsService;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.validation.constraints.NotNull;
-import java.net.URI;
 
 @Named
 @ExportAsService
@@ -29,7 +28,7 @@ public class SettingsServiceImpl implements SettingsService {
         final SettingsBean settingsBean = new SettingsBean();
 
         if (applicationPropertiesService.getBaseUrl() != null) {
-            settingsBean.setBaseUrl(applicationPropertiesService.getBaseUrl().toString());
+            settingsBean.setBaseUrl(applicationPropertiesService.getBaseUrl());
         }
 
         settingsBean.setTitle(applicationPropertiesService.getDisplayName());
@@ -44,7 +43,7 @@ public class SettingsServiceImpl implements SettingsService {
             @NotNull SettingsBean settingsBean) {
 
         if (settingsBean.getBaseUrl() != null) {
-            applicationPropertiesService.setBaseURL(URI.create(settingsBean.getBaseUrl()));
+            applicationPropertiesService.setBaseURL(settingsBean.getBaseUrl());
         }
 
         // Cannot set mode using ApplicationPropertiesService

--- a/src/test/java/de/aservo/confapi/bitbucket/filter/SysadminOnlyResourceFilterTest.java
+++ b/src/test/java/de/aservo/confapi/bitbucket/filter/SysadminOnlyResourceFilterTest.java
@@ -49,7 +49,7 @@ public class SysadminOnlyResourceFilterTest {
 
         final ApplicationUser applicationUser = mock(ApplicationUser.class);
         doReturn(Optional.of(applicationUser)).when(authentication).getUser();
-        doReturn(true).when(permissionService).hasUserPermission(applicationUser, SYS_ADMIN);
+        doReturn(true).when(permissionService).hasGlobalPermission(applicationUser, SYS_ADMIN);
 
         assertNull(sysadminOnlyResourceFilter.filter(null));
     }

--- a/src/test/java/de/aservo/confapi/bitbucket/model/util/ApplicationLinkBeanUtilTest.java
+++ b/src/test/java/de/aservo/confapi/bitbucket/model/util/ApplicationLinkBeanUtilTest.java
@@ -1,0 +1,104 @@
+package de.aservo.confapi.bitbucket.model.util;
+
+import com.atlassian.applinks.api.ApplicationId;
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.api.application.bamboo.BambooApplicationType;
+import com.atlassian.applinks.api.application.bitbucket.BitbucketApplicationType;
+import com.atlassian.applinks.api.application.confluence.ConfluenceApplicationType;
+import com.atlassian.applinks.api.application.crowd.CrowdApplicationType;
+import com.atlassian.applinks.api.application.fecru.FishEyeCrucibleApplicationType;
+import com.atlassian.applinks.api.application.jira.JiraApplicationType;
+import com.atlassian.applinks.api.application.refapp.RefAppApplicationType;
+import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
+import de.aservo.confapi.bitbucket.settings.setup.DefaultApplicationLink;
+import de.aservo.confapi.bitbucket.settings.setup.DefaultApplicationType;
+import de.aservo.confapi.commons.model.ApplicationLinkBean;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplicationLinkBeanUtilTest {
+
+    @Test
+    public void testToApplicationLinkBean() throws URISyntaxException {
+        final ApplicationId applicationId = new ApplicationId(UUID.randomUUID().toString());
+        final URI displayUri = new URI("http://localhost");
+        final URI rpcUri = new URI("http://rpc.example.com");
+        final ApplicationLink applicationLink = new DefaultApplicationLink(
+                applicationId, new DefaultApplicationType(), "test", displayUri, rpcUri, false, false);
+        final ApplicationLinkBean bean = ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink);
+
+        assertNotNull(bean);
+        assertEquals(bean.getName(), applicationLink.getName());
+        assertEquals(bean.getDisplayUrl(), applicationLink.getDisplayUrl());
+        assertEquals(bean.getRpcUrl(), applicationLink.getRpcUrl());
+        assertEquals(bean.isPrimary(), applicationLink.isPrimary());
+    }
+
+    @Test
+    public void testToApplicationLinkDetails() throws Exception {
+        final ApplicationLinkBean bean = ApplicationLinkBean.EXAMPLE_1;
+        final ApplicationLinkDetails linkDetails = ApplicationLinkBeanUtil.toApplicationLinkDetails(bean);
+
+        assertNotNull(linkDetails);
+        assertEquals(bean.getName(), linkDetails.getName());
+        assertEquals(bean.getDisplayUrl(), linkDetails.getDisplayUrl());
+        assertEquals(bean.getRpcUrl(), linkDetails.getRpcUrl());
+        assertEquals(bean.isPrimary(), linkDetails.isPrimary());
+    }
+
+    @Test
+    public void testLinkTypeGenerator() throws URISyntaxException {
+        for (ApplicationLinkBean.ApplicationLinkTypes linkType : ApplicationLinkBean.ApplicationLinkTypes.values()) {
+            ApplicationType applicationType = null;
+            switch (linkType) {
+                case BAMBOO:
+                    applicationType = mock(BambooApplicationType.class);
+                    break;
+                case JIRA:
+                    applicationType = mock(JiraApplicationType.class);
+                    break;
+                case BITBUCKET:
+                    applicationType = mock(BitbucketApplicationType.class);
+                    break;
+                case CONFLUENCE:
+                    applicationType = mock(ConfluenceApplicationType.class);
+                    break;
+                case FISHEYE:
+                    applicationType = mock(FishEyeCrucibleApplicationType.class);
+                    break;
+                case CROWD:
+                    applicationType = mock(CrowdApplicationType.class);
+                    break;
+            }
+            ApplicationId applicationId = new ApplicationId(UUID.randomUUID().toString());
+            URI uri = new URI("http://localhost");
+            ApplicationLink applicationLink = new DefaultApplicationLink(
+                    applicationId, applicationType, "test", uri, uri, false, false);
+            ApplicationLinkBean bean = ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink);
+            assertEquals(linkType, bean.getType());
+        }
+    }
+
+    @Test(expected = NotImplementedException.class)
+    public void testNonImplementedLinkTypeGenerator() throws URISyntaxException {
+        ApplicationType applicationType = mock(RefAppApplicationType.class);
+        ApplicationId applicationId = new ApplicationId(UUID.randomUUID().toString());
+        URI uri = new URI("http://localhost");
+        ApplicationLink applicationLink = new DefaultApplicationLink(
+                applicationId, applicationType, "test", uri, uri, false, false);
+        ApplicationLinkBeanUtil.toApplicationLinkBean(applicationLink);
+    }
+
+}

--- a/src/test/java/de/aservo/confapi/bitbucket/rest/SettingsServiceImplTest.java
+++ b/src/test/java/de/aservo/confapi/bitbucket/rest/SettingsServiceImplTest.java
@@ -44,7 +44,7 @@ public class SettingsServiceImplTest {
         final SettingsBean bean = settingsServiceImpl.getSettings();
 
         assertNotNull(applicationPropertiesService.getBaseUrl());
-        assertEquals(applicationPropertiesService.getBaseUrl().toString(), bean.getBaseUrl());
+        assertEquals(applicationPropertiesService.getBaseUrl(), bean.getBaseUrl());
         assertEquals(applicationPropertiesService.getMode().getId(), bean.getMode());
         assertEquals(applicationPropertiesService.getDisplayName(), bean.getTitle());
     }

--- a/src/test/java/de/aservo/confapi/bitbucket/service/ApplicationLinkServiceTest.java
+++ b/src/test/java/de/aservo/confapi/bitbucket/service/ApplicationLinkServiceTest.java
@@ -1,0 +1,241 @@
+package de.aservo.confapi.bitbucket.service;
+
+import com.atlassian.applinks.api.ApplicationId;
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.core.ApplinkStatus;
+import com.atlassian.applinks.core.ApplinkStatusService;
+import com.atlassian.applinks.core.DefaultApplinkStatus;
+import com.atlassian.applinks.internal.common.exception.NoAccessException;
+import com.atlassian.applinks.internal.common.exception.NoSuchApplinkException;
+import com.atlassian.applinks.internal.status.error.SimpleApplinkError;
+import com.atlassian.applinks.internal.status.oauth.ApplinkOAuthStatus;
+import com.atlassian.applinks.spi.auth.AuthenticationConfigurationException;
+import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
+import com.atlassian.applinks.spi.link.MutatingApplicationLinkService;
+import com.atlassian.applinks.spi.manifest.ManifestNotFoundException;
+import com.atlassian.applinks.spi.util.TypeAccessor;
+import de.aservo.confapi.bitbucket.model.DefaultAuthenticationScenario;
+import de.aservo.confapi.bitbucket.settings.setup.DefaultApplicationLink;
+import de.aservo.confapi.bitbucket.settings.setup.DefaultApplicationType;
+import de.aservo.confapi.commons.exception.BadRequestException;
+import de.aservo.confapi.commons.model.ApplicationLinkBean;
+import de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkStatus;
+import de.aservo.confapi.commons.model.ApplicationLinksBean;
+import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.atlassian.applinks.internal.common.status.oauth.OAuthConfig.createDefaultOAuthConfig;
+import static com.atlassian.applinks.internal.status.error.ApplinkErrorType.AUTH_LEVEL_MISMATCH;
+import static com.atlassian.applinks.internal.status.error.ApplinkErrorType.CONNECTION_REFUSED;
+import static de.aservo.confapi.bitbucket.model.util.ApplicationLinkBeanUtil.toApplicationLinkBean;
+import static de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkStatus.AVAILABLE;
+import static de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkStatus.CONFIGURATION_ERROR;
+import static de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkTypes.CROWD;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplicationLinkServiceTest {
+
+    @Mock
+    private MutatingApplicationLinkService mutatingApplicationLinkService;
+
+    @Mock
+    private TypeAccessor typeAccessor;
+
+    @Mock
+    private ApplinkStatusService applinkStatusService;
+
+    @Mock
+    private Validator validator;
+
+    private ApplicationLinkServiceImpl applicationLinkService;
+
+    @Before
+    public void setup() {
+        applicationLinkService = new ApplicationLinkServiceImpl(mutatingApplicationLinkService, typeAccessor, applinkStatusService, validator);
+    }
+
+    @Test
+    public void testDefaultDefaultAuthenticationScenarioImpl() {
+        DefaultAuthenticationScenario defaultAuthenticationScenario = new DefaultAuthenticationScenario();
+        assertTrue(defaultAuthenticationScenario.isCommonUserBase());
+        assertTrue(defaultAuthenticationScenario.isTrusted());
+    }
+
+    @Test
+    public void testGetApplicationLinks() throws URISyntaxException, NoAccessException, NoSuchApplinkException {
+        ApplicationLink applicationLink = createApplicationLink();
+        doReturn(Collections.singletonList(applicationLink)).when(mutatingApplicationLinkService).getApplicationLinks();
+        doReturn(createApplinkStatus(applicationLink, AVAILABLE)).when(applinkStatusService).getApplinkStatus(any());
+
+        ApplicationLinksBean applicationLinks = applicationLinkService.getApplicationLinks();
+
+        ApplicationLinkBean applicationLinkBean = toApplicationLinkBean(applicationLink);
+        applicationLinkBean.setStatus(AVAILABLE);
+        assertEquals(applicationLinks.getApplicationLinks().iterator().next(), applicationLinkBean);
+    }
+
+    @Test
+    public void testSetApplicationLinks()
+            throws URISyntaxException, ManifestNotFoundException, NoAccessException, NoSuchApplinkException {
+
+        ApplicationLink applicationLink = createApplicationLink();
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+        ApplicationLinksBean applicationLinksBean = new ApplicationLinksBean(Collections.singletonList(createApplicationLinkBean()));
+
+        doReturn(Collections.singletonList(applicationLink)).when(mutatingApplicationLinkService).getApplicationLinks();
+        doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                any(ApplicationType.class), any(ApplicationLinkDetails.class));
+        doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+        doReturn(createApplinkStatus(applicationLink, AVAILABLE)).when(applinkStatusService).getApplinkStatus(any());
+
+        ApplicationLinksBean applicationLinkResponse = applicationLinkService.setApplicationLinks(applicationLinksBean, true);
+
+        assertEquals(applicationLinkResponse.getApplicationLinks().iterator().next().getName(), applicationLinkBean.getName());
+        assertNotEquals(applicationLinkResponse, applicationLinkBean);
+    }
+
+    @Test
+    public void testAddApplicationLinkWithoutExistingTargetLink()
+            throws URISyntaxException, ManifestNotFoundException, NoAccessException, NoSuchApplinkException {
+
+        ApplicationLink applicationLink = createApplicationLink();
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+
+        doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                any(ApplicationType.class), any(ApplicationLinkDetails.class));
+        doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+        doReturn(createApplinkStatus(applicationLink, AVAILABLE)).when(applinkStatusService).getApplinkStatus(any());
+
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean, true);
+
+        assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
+        assertNotEquals(applicationLinkResponse, applicationLinkBean);
+    }
+
+    @Test
+    public void testAddApplicationLinkWithExistingTargetLink() throws URISyntaxException, ManifestNotFoundException, NoAccessException, NoSuchApplinkException {
+        ApplicationLink applicationLink = createApplicationLink();
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+
+        doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                any(ApplicationType.class), any(ApplicationLinkDetails.class));
+        doReturn(applicationLink).when(mutatingApplicationLinkService).getPrimaryApplicationLink(any());
+        doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+        doReturn(createApplinkStatus(applicationLink, AVAILABLE)).when(applinkStatusService).getApplinkStatus(any());
+
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean, true);
+
+        assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
+        assertNotEquals(applicationLinkResponse, applicationLinkBean);
+    }
+
+    @Test
+    public void testAddApplicationLinkWithAuthenticatorErrorIgnored() throws URISyntaxException, ManifestNotFoundException, AuthenticationConfigurationException, NoAccessException, NoSuchApplinkException {
+        ApplicationLink applicationLink = createApplicationLink();
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+
+        doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                any(ApplicationType.class), any(ApplicationLinkDetails.class));
+        doReturn(applicationLink).when(mutatingApplicationLinkService).getPrimaryApplicationLink(any());
+        doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+        doThrow(new AuthenticationConfigurationException("")).when(mutatingApplicationLinkService).configureAuthenticationForApplicationLink(any(), any(), any(), any());
+        doReturn(createApplinkStatus(applicationLink, CONFIGURATION_ERROR)).when(applinkStatusService).getApplinkStatus(any());
+
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean, true);
+
+        assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
+        assertNotEquals(applicationLinkResponse, applicationLinkBean);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testAddApplicationLinkWithAuthenticatorErrorNOTIgnored() throws URISyntaxException, ManifestNotFoundException, AuthenticationConfigurationException {
+        ApplicationLink applicationLink = createApplicationLink();
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+
+        doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                any(ApplicationType.class), any(ApplicationLinkDetails.class));
+        doReturn(applicationLink).when(mutatingApplicationLinkService).getPrimaryApplicationLink(any());
+        doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+        doThrow(new AuthenticationConfigurationException("")).when(mutatingApplicationLinkService).configureAuthenticationForApplicationLink(any(), any(), any(), any());
+
+        ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean, false);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testAddApplicationLinkMissingLinkType() throws URISyntaxException {
+
+        Set<ConstraintViolation<Object>> violations = new HashSet<>();
+        violations.add(ConstraintViolationImpl.forBeanValidation("", null, null, "",
+                null, null, null, null, null, null, null, null));
+        doReturn(violations).when(validator).validate(any());
+
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+        applicationLinkBean.setType(null);
+
+        applicationLinkService.addApplicationLink(applicationLinkBean, true);
+    }
+
+    @Test
+    public void testApplicationLinkTypeConverter() throws URISyntaxException, ManifestNotFoundException, NoAccessException, NoSuchApplinkException {
+        for (ApplicationLinkBean.ApplicationLinkTypes linkType : ApplicationLinkBean.ApplicationLinkTypes.values()) {
+            ApplicationLink applicationLink = createApplicationLink();
+            ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
+            applicationLinkBean.setType(linkType);
+
+            doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
+                    any(ApplicationType.class), any(ApplicationLinkDetails.class));
+            doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
+            doReturn(createApplinkStatus(applicationLink, AVAILABLE)).when(applinkStatusService).getApplinkStatus(any());
+
+            ApplicationLinkBean applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkBean, true);
+
+            assertEquals(applicationLinkResponse.getName(), applicationLinkBean.getName());
+        }
+    }
+
+    private ApplicationLinkBean createApplicationLinkBean() throws URISyntaxException {
+        ApplicationLinkBean bean = toApplicationLinkBean(createApplicationLink());
+        bean.setType(CROWD);
+        bean.setUsername("test");
+        bean.setPassword("test");
+        return bean;
+    }
+
+    private ApplicationLink createApplicationLink() throws URISyntaxException {
+        ApplicationId applicationId = new ApplicationId(UUID.randomUUID().toString());
+        URI uri = new URI("http://localhost");
+        return new DefaultApplicationLink(applicationId, new DefaultApplicationType(), "test", uri, uri, false, false);
+    }
+
+    private ApplinkStatus createApplinkStatus(ApplicationLink link, ApplicationLinkStatus linkStatus) {
+        ApplinkOAuthStatus oAuthStatus = new ApplinkOAuthStatus(createDefaultOAuthConfig(), createDefaultOAuthConfig());
+        switch (linkStatus) {
+            case AVAILABLE:
+                return DefaultApplinkStatus.working (link, oAuthStatus, oAuthStatus);
+            case UNAVAILABLE:
+                return DefaultApplinkStatus.disabled (link, new SimpleApplinkError(CONNECTION_REFUSED));
+            case CONFIGURATION_ERROR:
+            default:
+                return DefaultApplinkStatus.configError (link, oAuthStatus, oAuthStatus, new SimpleApplinkError(AUTH_LEVEL_MISMATCH));
+        }
+    }
+}

--- a/src/test/java/de/aservo/confapi/bitbucket/settings/setup/DefaultApplicationLink.java
+++ b/src/test/java/de/aservo/confapi/bitbucket/settings/setup/DefaultApplicationLink.java
@@ -1,0 +1,61 @@
+package de.aservo.confapi.bitbucket.settings.setup;
+
+import com.atlassian.applinks.api.ApplicationId;
+import com.atlassian.applinks.api.ApplicationLink;
+import com.atlassian.applinks.api.ApplicationLinkRequestFactory;
+import com.atlassian.applinks.api.ApplicationType;
+import com.atlassian.applinks.api.auth.AuthenticationProvider;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.net.URI;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DefaultApplicationLink implements ApplicationLink {
+
+    private ApplicationId id;
+    private ApplicationType type;
+    private String name;
+    private URI displayUrl;
+    private URI rpcUrl;
+    private boolean primary;
+    private boolean system;
+
+    @Override
+    public Object getProperty(String s) {
+        return null;
+    }
+
+    @Override
+    public Object putProperty(String s, Object o) {
+        return null;
+    }
+
+    @Override
+    public Object removeProperty(String s) {
+        return null;
+    }
+
+    @Override
+    public ApplicationLinkRequestFactory createAuthenticatedRequestFactory() {
+        return null;
+    }
+
+    @Override
+    public ApplicationLinkRequestFactory createAuthenticatedRequestFactory(Class<? extends AuthenticationProvider> aClass) {
+        return null;
+    }
+
+    @Override
+    public ApplicationLinkRequestFactory createImpersonatingAuthenticatedRequestFactory() {
+        return null;
+    }
+
+    @Override
+    public ApplicationLinkRequestFactory createNonImpersonatingAuthenticatedRequestFactory() {
+        return null;
+    }
+}

--- a/src/test/java/de/aservo/confapi/bitbucket/settings/setup/DefaultApplicationType.java
+++ b/src/test/java/de/aservo/confapi/bitbucket/settings/setup/DefaultApplicationType.java
@@ -1,0 +1,23 @@
+package de.aservo.confapi.bitbucket.settings.setup;
+
+import com.atlassian.applinks.api.application.jira.JiraApplicationType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.URI;
+
+public class DefaultApplicationType implements JiraApplicationType {
+
+    @Nonnull
+    @Override
+    public String getI18nKey() {
+        return "";
+    }
+
+    @Nullable
+    @Override
+    public URI getIconUrl() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
This commit implements the application-links interface for Bitbucket as per
commons API definition.

In addition the correct sys-admin check was fixed in SysAdminOnlyResourceFilter class.

In order to comply woíth commons 0.0.20 the existing Settings service needed to be
adjusted as well.