### PR TITLE
directories service class name fix

### DIFF
--- a/src/main/java/de/aservo/confapi/bitbucket/service/ApplicationLinksServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/bitbucket/service/ApplicationLinksServiceImpl.java
@@ -44,9 +44,9 @@ import static de.aservo.confapi.commons.util.BeanValidationUtil.processValidatio
 
 @Named
 @ExportAsService(ApplicationLinksService.class)
-public class ApplicationLinkServiceImpl implements ApplicationLinksService {
+public class ApplicationLinksServiceImpl implements ApplicationLinksService {
 
-    private static final Logger log = LoggerFactory.getLogger(ApplicationLinkServiceImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(ApplicationLinksServiceImpl.class);
 
     private final MutatingApplicationLinkService mutatingApplicationLinkService;
     private final TypeAccessor typeAccessor;
@@ -54,10 +54,10 @@ public class ApplicationLinkServiceImpl implements ApplicationLinksService {
     private final Validator validator;
 
     @Inject
-    public ApplicationLinkServiceImpl(@ComponentImport MutatingApplicationLinkService mutatingApplicationLinkService,
-                                      @ComponentImport TypeAccessor typeAccessor,
-                                      @ComponentImport ApplinkStatusService applinkStatusService,
-                                      @ComponentImport Validator validator) {
+    public ApplicationLinksServiceImpl(@ComponentImport MutatingApplicationLinkService mutatingApplicationLinkService,
+                                       @ComponentImport TypeAccessor typeAccessor,
+                                       @ComponentImport ApplinkStatusService applinkStatusService,
+                                       @ComponentImport Validator validator) {
         this.mutatingApplicationLinkService = mutatingApplicationLinkService;
         this.typeAccessor = typeAccessor;
         this.applinkStatusService = applinkStatusService;

--- a/src/main/java/de/aservo/confapi/bitbucket/service/DirectoriesServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/bitbucket/service/DirectoriesServiceImpl.java
@@ -27,15 +27,15 @@ import static java.lang.String.format;
 
 @Named
 @ExportAsService(DirectoriesService.class)
-public class DirectoryServiceImpl implements DirectoriesService {
+public class DirectoriesServiceImpl implements DirectoriesService {
 
-    private static final Logger log = LoggerFactory.getLogger(DirectoryServiceImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(DirectoriesServiceImpl.class);
 
     private final CrowdDirectoryService crowdDirectoryService;
     private final Validator validator;
 
     @Inject
-    public DirectoryServiceImpl(
+    public DirectoriesServiceImpl(
             @ComponentImport CrowdDirectoryService crowdDirectoryService,
             @ComponentImport Validator validator) {
         this.crowdDirectoryService = checkNotNull(crowdDirectoryService);

--- a/src/test/java/de/aservo/confapi/bitbucket/service/ApplicationLinksServiceTest.java
+++ b/src/test/java/de/aservo/confapi/bitbucket/service/ApplicationLinksServiceTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ApplicationLinkServiceTest {
+public class ApplicationLinksServiceTest {
 
     @Mock
     private MutatingApplicationLinkService mutatingApplicationLinkService;
@@ -66,11 +66,11 @@ public class ApplicationLinkServiceTest {
     @Mock
     private Validator validator;
 
-    private ApplicationLinkServiceImpl applicationLinkService;
+    private ApplicationLinksServiceImpl applicationLinkService;
 
     @Before
     public void setup() {
-        applicationLinkService = new ApplicationLinkServiceImpl(mutatingApplicationLinkService, typeAccessor, applinkStatusService, validator);
+        applicationLinkService = new ApplicationLinksServiceImpl(mutatingApplicationLinkService, typeAccessor, applinkStatusService, validator);
     }
 
     @Test

--- a/src/test/java/de/aservo/confapi/bitbucket/service/DirectoriesServiceTest.java
+++ b/src/test/java/de/aservo/confapi/bitbucket/service/DirectoriesServiceTest.java
@@ -19,7 +19,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import javax.validation.ConstraintViolation;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,7 +36,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DirectoryServiceTest {
+public class DirectoriesServiceTest {
 
     @Mock
     private CrowdDirectoryService crowdDirectoryService;
@@ -45,15 +44,15 @@ public class DirectoryServiceTest {
     @Mock
     private Validator validator;
 
-    private DirectoryServiceImpl directoryService;
+    private DirectoriesServiceImpl directoryService;
 
     @Before
     public void setup() {
-        directoryService = new DirectoryServiceImpl(crowdDirectoryService, validator);
+        directoryService = new DirectoriesServiceImpl(crowdDirectoryService, validator);
     }
 
     @Test
-    public void testGetDirectories() throws URISyntaxException {
+    public void testGetDirectories() {
         Directory directory = createDirectory();
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
 


### PR DESCRIPTION
This commit fixes applinks and directories service class name following plural naming convention.